### PR TITLE
Add Express server and React demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,30 @@ Ardoma RPG é um jogo de interpretação de papéis (RPG) em que os jogadores s�
 
 ---
 
+## 💻 Nova Estrutura (Node.js + Express + React)
+
+Com a expansão do projeto, adicionamos um pequeno backend em **Node.js** com **Express** e uma estrutura preparada para um frontend em **React**. A API oferece rotas para:
+
+1. **Login** (`POST /login`) – retorna um token fictício.
+2. **Criação e salvamento de fichas** (`POST /characters` e `GET /characters/:id`).
+3. **Oráculos** (`GET /oracles/campaign` e `GET /oracles/masterless`).
+4. **Rolagem de dados** (`GET /dice/:sides/:count`).
+
+Os dados são mantidos em memória apenas para demonstração. Para algo em produção, configure um banco de dados (PostgreSQL ou MongoDB) e ajuste os modelos.
+
+Para iniciar o servidor durante o desenvolvimento:
+
+```bash
+npm install
+npm run dev
+```
+
+Isso executará `server/index.js` com nodemon.
+
+Abra `client/index.html` em um navegador para testar a tela de login usando React.
+
+---
+
 ## 🚀 Como Funciona o Cálculo?
 
 ### 1. Atributos

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Ardoma RPG App</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    function App() {
+      const [username, setUsername] = React.useState('');
+      const [token, setToken] = React.useState('');
+
+      const login = async () => {
+        const res = await fetch('http://localhost:3000/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username })
+        });
+        const data = await res.json();
+        setToken(data.token);
+      };
+
+      return (
+        <div>
+          <h1>Ardoma RPG</h1>
+          {token ? (
+            <p>Token: {token}</p>
+          ) : (
+            <div>
+              <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Usuário" />
+              <button onClick={login}>Login</button>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
 
     <button onclick="gerarFicha()">Atualizar Ficha</button>
     <button onclick="gerarPDF()">Gerar PDF</button>
+    <button onclick="rolarDados(20,1)">Rolagem d20</button>
   </div>
 
   <script src="script.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ardoma-rpg",
+  "version": "1.0.0",
+  "description": "Este projeto é um **sistema digital para criar fichas de personagem** do Ardoma RPG, totalmente baseado nas regras oficiais descritas no livro **Ardoma RPG V3**.",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "dev": "nodemon server/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -103,6 +103,12 @@ function gerarPDF() {
   });
 }
 
+async function rolarDados(sides, count) {
+  const res = await fetch(`http://localhost:3000/dice/${sides}/${count}`);
+  const data = await res.json();
+  alert(`Rolagens: ${data.rolls.join(', ')}`);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   atualizarRacialBonus();
   atributosIds.forEach(id => {

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,73 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(cors());
+app.use(express.json());
+
+// In-memory storage for demo purposes
+const characters = new Map();
+let currentId = 1;
+
+app.post('/login', (req, res) => {
+  const { username } = req.body;
+  if (!username) {
+    return res.status(400).json({ error: 'Username required' });
+  }
+  // Fake token generation for demo
+  const token = `token-${Date.now()}`;
+  res.json({ token });
+});
+
+app.post('/characters', (req, res) => {
+  const character = { id: currentId++, ...req.body };
+  characters.set(character.id, character);
+  res.status(201).json(character);
+});
+
+app.get('/characters/:id', (req, res) => {
+  const char = characters.get(Number(req.params.id));
+  if (!char) {
+    return res.status(404).json({ error: 'Character not found' });
+  }
+  res.json(char);
+});
+
+// Simple campaign oracle
+const campaignHooks = [
+  'A guild seeks brave adventurers',
+  'Um artefato poderoso foi perdido',
+  'Uma nova ameaça surge nas sombras'
+];
+
+app.get('/oracles/campaign', (req, res) => {
+  const hook = campaignHooks[Math.floor(Math.random() * campaignHooks.length)];
+  res.json({ hook });
+});
+
+const soloPrompts = [
+  'Um aliado inesperado aparece',
+  'Encontre uma pista misteriosa',
+  'Um inimigo revela seu plano'
+];
+
+app.get('/oracles/masterless', (req, res) => {
+  const prompt = soloPrompts[Math.floor(Math.random() * soloPrompts.length)];
+  res.json({ prompt });
+});
+
+app.get('/dice/:sides/:count?', (req, res) => {
+  const sides = parseInt(req.params.sides, 10) || 6;
+  const count = parseInt(req.params.count, 10) || 1;
+  const rolls = [];
+  for (let i = 0; i < count; i++) {
+    rolls.push(1 + Math.floor(Math.random() * sides));
+  }
+  res.json({ sides, count, rolls });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add package.json with Express, cors and nodemon
- create Express API for login, characters, oracles and dice
- add small React front-end example
- enable dice roll button in main HTML
- document new stack and usage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -c server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_686a93a8d4e4832b81d4392b7a90eb31